### PR TITLE
Look for .git directories in parent directories

### DIFF
--- a/includes/admin/callbacks.php
+++ b/includes/admin/callbacks.php
@@ -7,6 +7,7 @@
 
 namespace Symlinked_Plugin_Branch\Admin;
 
+use function Symlinked_Plugin_Branch\Utilities\current_git_repo_path;
 use function Symlinked_Plugin_Branch\Utilities\current_git_branch;
 use function Symlinked_Plugin_Branch\Utilities\get_plugins_with_symlinks;
 use function Symlinked_Plugin_Branch\Utilities\replace_home_with_tilde;
@@ -79,7 +80,9 @@ function display_column_content( $plugin_file, $plugin_data ) {
         return;
     }
 
-    $target_path = replace_home_with_tilde( readlink( $plugin_path ) );
+    $git_repo_path = current_git_repo_path( $plugin_path );
+
+    $target_path = replace_home_with_tilde( $git_repo_path );
     $branch = current_git_branch( $plugin_path );
 
     echo "

--- a/includes/utilities/functions.php
+++ b/includes/utilities/functions.php
@@ -12,6 +12,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Returns the git repo directory of the plugin. It will look up into
+ * parent directories as the symlink's origin may be a subdirectory
+ * of the Git repository.
+ *
+ * @param string $plugin_path The path of the plugin directory.
+ *
+ * @return string The path containing the .git directory of the symlinked plugin.
+ *                or an empty string if a git repo was not found.
+ */
+function current_git_repo_path( $plugin_path ) {
+    // Ensure the plugin path is an absolute path and resolve symlinks
+    $resolved_path = realpath( $plugin_path );
+
+    // Check for .git directory
+    $git_dir_exists = file_exists( $resolved_path . '/.git' );
+
+    while ( !$git_dir_exists && $resolved_path !== '/' ) {
+      $resolved_path = dirname( $resolved_path );
+      // Check for .git directory
+      $git_dir_exists = file_exists( $resolved_path . '/.git' );
+    }
+
+    if ( !$git_dir_exists || $resolved_path === '/' ) {
+        return '';
+    }
+
+    return $resolved_path;
+}
+
+/**
  * Returns the git branch of the given directory.
  *
  * @param string $plugin_path The path of the plugin directory.
@@ -31,16 +61,10 @@ function current_git_branch( $plugin_path ) {
         return 'Git is not installed or not in the PATH';
     }
 
-    // Check for .git directory
-    $git_dir_exists = file_exists( $resolved_path . '/.git' );
+    // Check for .git repo directory
+    $git_repo_dir = current_git_repo_path( $plugin_path );
 
-    while ( !$git_dir_exists && $resolved_path !== '/' ) {
-      $resolved_path = dirname( $resolved_path );
-      // Check for .git directory
-      $git_dir_exists = file_exists( $resolved_path . '/.git' );
-    }
-
-    if ( !$git_dir_exists ) {
+    if ( $git_repo_dir === '' ) {
         return 'No .git directory found in resolved path: ' . htmlspecialchars( $resolved_path );
     }
 

--- a/includes/utilities/functions.php
+++ b/includes/utilities/functions.php
@@ -34,6 +34,12 @@ function current_git_branch( $plugin_path ) {
     // Check for .git directory
     $git_dir_exists = file_exists( $resolved_path . '/.git' );
 
+    while ( !$git_dir_exists && $resolved_path !== '/' ) {
+      $resolved_path = dirname( $resolved_path );
+      // Check for .git directory
+      $git_dir_exists = file_exists( $resolved_path . '/.git' );
+    }
+
     if ( !$git_dir_exists ) {
         return 'No .git directory found in resolved path: ' . htmlspecialchars( $resolved_path );
     }


### PR DESCRIPTION
Allows the plugin to look in parent directories for the `.git` directory.

In our team we have multiple plugins in a single repo. e.g.:

 - `/my-plugin/src/free-plugin.php`
 - `/my-plugin/src/pro-plugin.php`

With `.git` in `/my-plugin/.git`

This appears as:

<img width="929" alt="Screenshot 2025-02-03 at 13 34 17" src="https://github.com/user-attachments/assets/a769673a-9bf4-4b5c-8295-54e25ad8f733" />

This should probably be a more sophisticated check. Like, when you hit the directory that contains the symlinked plugin, you should probably stop.

But I did this today and thought it might be something you can iterate on (or maybe I will later when I have more time).

Thanks!